### PR TITLE
Fixed unescaped ? when searching backwards with #

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -1,15 +1,15 @@
 " From http://got-ravings.blogspot.com/2008/07/vim-pr0n-visual-search-mappings.html
 
 " makes * and # work on visual mode too.
-function! s:VSetSearch()
+function! s:VSetSearch(cmdtype)
   let temp = @s
   norm! gv"sy
-  let @/ = '\V' . substitute(escape(@s, '/\'), '\n', '\\n', 'g')
+  let @/ = '\V' . substitute(escape(@s, a:cmdtype.'\'), '\n', '\\n', 'g')
   let @s = temp
 endfunction
 
-xnoremap * :<C-u>call <SID>VSetSearch()<CR>/<C-R>=@/<CR><CR>
-xnoremap # :<C-u>call <SID>VSetSearch()<CR>?<C-R>=@/<CR><CR>
+xnoremap * :<C-u>call <SID>VSetSearch('/')<CR>/<C-R>=@/<CR><CR>
+xnoremap # :<C-u>call <SID>VSetSearch('?')<CR>?<C-R>=@/<CR><CR>
 
 " recursively vimgrep for word under cursor or selection if you hit leader-star
 nmap <leader>* :execute 'noautocmd vimgrep /\V' . substitute(escape(expand("<cword>"), '\'), '\n', '\\n', 'g') . '/ **'<CR>


### PR DESCRIPTION
Hi Drew!

Question marks weren't being escaped when searching backwards. This lead
to problems when searching for a Visual selection like "apple?e".

Here's the part you might be interested in, though: The code for
visual-star-search is in your book (version P1.0, tip 86); the fix I'm
sending you is actually discussed in your book too, in tip 78!

You might perhaps want to fix tip 86 and cross-reference to 78?

Thanks and have a nice day!

David
