### PR TITLE
Update visual-star-search.vim

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -9,6 +9,7 @@ function! s:VSetSearch(cmdtype)
 endfunction
 
 xnoremap * :<C-u>call <SID>VSetSearch('/')<CR>/<C-R>=@/<CR><CR>
+xnoremap <kMultiply> :<C-u>call <SID>VSetSearch('/')<CR>/<C-R>=@/<CR><CR>
 xnoremap # :<C-u>call <SID>VSetSearch('?')<CR>?<C-R>=@/<CR><CR>
 
 " recursively vimgrep for word under cursor or selection if you hit leader-star


### PR DESCRIPTION
Added
xnoremap <kMultiply> :<C-u>call <SID>VSetSearch('/')<CR>/<C-R>=@/<CR><CR>
so that "_" on numerical keyboard (keypad) works the same as Shift-8 "_".

See also
http://vimdoc.sourceforge.net/htmldoc/term.html#<kMultiply>
