### PR TITLE
No jumping and reselect last selection

### DIFF
--- a/plugin/visual-star-search.vim
+++ b/plugin/visual-star-search.vim
@@ -8,7 +8,7 @@ function! s:VSetSearch(cmdtype)
   let @s = temp
 endfunction
 
-xnoremap * :<C-u>call <SID>VSetSearch('/')<CR>/<C-R>=@/<CR><CR>
+xnoremap * :<C-u>call <SID>VSetSearch('/')<CR>:set hls<CR>gv
 xnoremap # :<C-u>call <SID>VSetSearch('?')<CR>?<C-R>=@/<CR><CR>
 
 " recursively vimgrep for word under cursor or selection if you hit leader-star


### PR DESCRIPTION
Makes * search of visual selection not jump.
Re-selects your visual selection with gv so you can change it more easy.
Sets hls so you see the matches.